### PR TITLE
Add device streaming via Redis & websockets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: pip install ruff pytest pytest-asyncio httpx fastapi uvicorn[standard] sqlmodel sqlalchemy asyncpg python-jose[cryptography] passlib[bcrypt] pydantic-settings slowapi
+        run: pip install ruff pytest pytest-asyncio httpx fastapi uvicorn[standard] sqlmodel sqlalchemy asyncpg python-jose[cryptography] passlib[bcrypt] pydantic-settings slowapi redis websockets testcontainers[redis]
       - name: Lint
         run: ruff .
       - name: Test

--- a/README.md
+++ b/README.md
@@ -23,5 +23,16 @@ Access the Traefik dashboard at `https://localhost/dashboard`.
 - **redis** – Redis 7
 - **objstore** – MinIO object storage
 
+## Live streaming quick start
+Send telemetry samples and consume them in real time:
+
+```bash
+curl -X POST https://device.localhost/v1/stream/device123 \
+  -H 'Content-Type: application/json' \
+  -d '{"ts":"2025-06-19T09:41:15Z","type":"temperature","value":23.7,"unit":"°C"}'
+
+websocat ws://localhost:8080/ws/stream/device123
+```
+
 ## Development
 Use the provided `.devcontainer` folder with VS Code Remote Containers for an integrated environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
   gateway:
     build: ./services/gateway
     env_file: ./services/gateway/.env.example
+    ports:
+      - "8080:8000"
     depends_on:
       - auth-api
     labels:

--- a/services/auth-api/app/api/routes.py
+++ b/services/auth-api/app/api/routes.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import select
 
-from common import RefreshToken, User, create_access_token, hash_password, verify_password
+from common import User, create_access_token, hash_password, verify_password
 from ..core.config import settings
 from ..db.session import get_session
 

--- a/services/device-api/.env.example
+++ b/services/device-api/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql+asyncpg://smartsec:smartsec@db:5432/smartsecurity
+REDIS_URL=redis://redis:6379/0

--- a/services/device-api/app/api/routes.py
+++ b/services/device-api/app/api/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlmodel import select
 
 from common import Device

--- a/services/device-api/app/core/config.py
+++ b/services/device-api/app/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     database_url: str = "postgresql+asyncpg://smartsec:smartsec@db:5432/smartsecurity"
+    redis_url: str = "redis://redis:6379/0"
 
 
 settings = Settings()

--- a/services/device-api/app/main.py
+++ b/services/device-api/app/main.py
@@ -1,8 +1,11 @@
 from fastapi import FastAPI
-from .api.routes import router
+
+from .api.routes import router as api_router
+from .routes.stream import router as stream_router
 
 app = FastAPI(title="Device API", version="0.1.0")
-app.include_router(router, prefix="/v1")
+app.include_router(api_router, prefix="/v1")
+app.include_router(stream_router, prefix="/v1")
 
 
 @app.get("/v1/health")

--- a/services/device-api/app/models/stream.py
+++ b/services/device-api/app/models/stream.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class StreamPayload(BaseModel):
+    ts: datetime = Field(..., description="Timestamp of the sample")
+    type: str = Field(..., description="Metric type")
+    value: float = Field(..., description="Metric value")
+    unit: str = Field(..., description="Unit of measurement")
+

--- a/services/device-api/app/routes/stream.py
+++ b/services/device-api/app/routes/stream.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+import redis.asyncio as redis
+
+from ..core.config import settings
+from ..models.stream import StreamPayload
+
+router = APIRouter()
+
+redis_client = redis.from_url(settings.redis_url)
+
+
+@router.post("/stream/{device_id}", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_stream(device_id: str, payload: StreamPayload) -> None:
+    channel = f"stream:{device_id}"
+    await redis_client.publish(channel, payload.model_dump_json())
+

--- a/services/device-api/pyproject.toml
+++ b/services/device-api/pyproject.toml
@@ -12,6 +12,7 @@ sqlmodel = "^0.0.8"
 sqlalchemy = ">=1.4.17,<1.5.0"
 asyncpg = "^0.28.0"
 httpx = "^0.25.0"
+redis = "^5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/services/device-api/tests/test_stream.py
+++ b/services/device-api/tests/test_stream.py
@@ -1,0 +1,49 @@
+import json
+from datetime import datetime
+
+import pytest
+from httpx import AsyncClient
+from redis.asyncio import Redis
+from testcontainers.redis import RedisContainer
+
+from app.main import app
+from app.core import config as config_module
+from app.models.stream import StreamPayload
+
+@pytest.mark.asyncio
+async def test_ingest_publishes() -> None:
+    with RedisContainer() as redis_container:
+        config_module.settings.redis_url = redis_container.get_connection_url()
+        redis_client = Redis.from_url(config_module.settings.redis_url)
+        pubsub = redis_client.pubsub()
+        await pubsub.subscribe("stream:device1")
+
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            payload = {
+                "ts": datetime.utcnow().isoformat() + "Z",
+                "type": "temperature",
+                "value": 25.0,
+                "unit": "C",
+            }
+            resp = await ac.post("/v1/stream/device1", json=payload)
+            assert resp.status_code == 202
+
+        message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=2.0)
+        assert message is not None
+        data = json.loads(message["data"].decode())
+        assert data["type"] == "temperature"
+
+        await pubsub.unsubscribe("stream:device1")
+        await pubsub.close()
+        await redis_client.close()
+
+
+def test_model_validation() -> None:
+    data = {
+        "ts": "2025-06-19T09:41:15Z",
+        "type": "humidity",
+        "value": 50.1,
+        "unit": "%",
+    }
+    payload = StreamPayload(**data)
+    assert payload.type == "humidity"

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -1,1 +1,2 @@
 AUTH_API_URL=http://auth-api:8000
+REDIS_URL=redis://redis:6379/0

--- a/services/gateway/app/core/config.py
+++ b/services/gateway/app/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     auth_api_url: str = "http://auth-api:8000"
+    redis_url: str = "redis://redis:6379/0"
 
 
 settings = Settings()

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 from httpx import AsyncClient
 from .core.config import settings
+from .ws.stream import stream_ws
 
 app = FastAPI(title="Gateway")
+app.add_api_websocket_route("/ws/stream/{device_id}", stream_ws)
 
 
 @app.get("/v1/health")

--- a/services/gateway/app/ws/stream.py
+++ b/services/gateway/app/ws/stream.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from fastapi import WebSocket, WebSocketDisconnect
+import redis.asyncio as redis
+
+from ..core.config import settings
+
+redis_client = redis.from_url(settings.redis_url)
+
+
+async def stream_ws(websocket: WebSocket, device_id: str) -> None:
+    await websocket.accept()
+    pubsub = redis_client.pubsub()
+    channel = f"stream:{device_id}"
+    await pubsub.subscribe(channel)
+    last_activity = time.monotonic()
+
+    async def ping_loop() -> None:
+        nonlocal last_activity
+        while True:
+            await asyncio.sleep(30)
+            if time.monotonic() - last_activity > 120:
+                await websocket.close()
+                break
+            await websocket.send_json({"type": "ping"})
+
+    async def forward_loop() -> None:
+        nonlocal last_activity
+        try:
+            while True:
+                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                if message:
+                    await websocket.send_text(message["data"].decode())
+                    last_activity = time.monotonic()
+        finally:
+            await pubsub.unsubscribe(channel)
+            await pubsub.close()
+
+    ping_task = asyncio.create_task(ping_loop())
+    forward_task = asyncio.create_task(forward_loop())
+    try:
+        await asyncio.gather(ping_task, forward_task)
+    except WebSocketDisconnect:
+        ping_task.cancel()
+        forward_task.cancel()
+        await pubsub.unsubscribe(channel)
+        await pubsub.close()
+

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.12"
 fastapi = "^0.104.0"
 uvicorn = {extras = ["standard"], version = "^0.23.0"}
 httpx = "^0.25.0"
+redis = "^5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/services/gateway/tests/test_ws.py
+++ b/services/gateway/tests/test_ws.py
@@ -1,0 +1,33 @@
+import asyncio
+import json
+
+import pytest
+import websockets
+from redis.asyncio import Redis
+from testcontainers.redis import RedisContainer
+import uvicorn
+
+from app.main import app
+from app.core import config as config_module
+
+
+@pytest.mark.asyncio
+async def test_websocket_stream() -> None:
+    with RedisContainer() as redis_container:
+        config_module.settings.redis_url = redis_container.get_connection_url()
+        server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=8765, log_level="info"))
+        task = asyncio.create_task(server.serve())
+        await asyncio.sleep(0.5)
+
+        redis_client = Redis.from_url(config_module.settings.redis_url)
+        ws = await websockets.connect("ws://127.0.0.1:8765/ws/stream/device1")
+
+        await redis_client.publish("stream:device1", json.dumps({"ts": "2025-06-19T09:41:15Z", "type": "temperature", "value": 42, "unit": "C"}))
+        data = json.loads(await ws.recv())
+        assert data["value"] == 42
+
+        await ws.close()
+        server.should_exit = True
+        await task
+        await redis_client.close()
+

--- a/services/metrics-api/.env.example
+++ b/services/metrics-api/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql+asyncpg://smartsec:smartsec@db:5432/smartsecurity
+REDIS_URL=redis://redis:6379/0

--- a/services/metrics-api/app/consumers/stream_consumer.py
+++ b/services/metrics-api/app/consumers/stream_consumer.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import redis.asyncio as redis
+
+from ..core.config import settings
+from ..db.session import SessionLocal
+from ..models.device_metric import DeviceMetric
+
+redis_client = redis.from_url(settings.redis_url)
+
+
+async def consume_streams() -> None:
+    pubsub = redis_client.pubsub()
+    await pubsub.psubscribe("stream:*")
+    try:
+        while True:
+            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+            if not message:
+                await asyncio.sleep(0.1)
+                continue
+            channel = message["channel"].decode()
+            device_id = channel.split(":", 1)[1]
+            data = json.loads(message["data"].decode())
+            metric = DeviceMetric(device_id=device_id, **data)
+            async with SessionLocal() as session:
+                session.add(metric)
+                await session.commit()
+    finally:
+        await pubsub.close()
+

--- a/services/metrics-api/app/core/config.py
+++ b/services/metrics-api/app/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     database_url: str = "postgresql+asyncpg://smartsec:smartsec@db:5432/smartsecurity"
+    redis_url: str = "redis://redis:6379/0"
 
 
 settings = Settings()

--- a/services/metrics-api/app/main.py
+++ b/services/metrics-api/app/main.py
@@ -1,8 +1,17 @@
 from fastapi import FastAPI
-from .api.routes import router
+from .api.routes import router as api_router
+from .routes.metrics import router as metrics_router
+from .consumers.stream_consumer import consume_streams
 
 app = FastAPI(title="Metrics API", version="0.1.0")
-app.include_router(router, prefix="/v1")
+app.include_router(api_router, prefix="/v1")
+app.include_router(metrics_router, prefix="/v1")
+
+
+@app.on_event("startup")
+async def start_consumer() -> None:
+    import asyncio
+    asyncio.create_task(consume_streams())
 
 
 @app.get("/v1/health")

--- a/services/metrics-api/app/models/device_metric.py
+++ b/services/metrics-api/app/models/device_metric.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlmodel import Field, SQLModel
+
+
+class DeviceMetric(SQLModel, table=True):
+    __tablename__ = "device_metrics"
+
+    id: int | None = Field(default=None, primary_key=True)
+    device_id: str
+    ts: datetime
+    type: str
+    value: float
+    unit: str
+

--- a/services/metrics-api/app/routes/metrics.py
+++ b/services/metrics-api/app/routes/metrics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlmodel import select
+
+from ..db.session import get_session
+from ..models.device_metric import DeviceMetric
+
+router = APIRouter()
+
+
+def _parse_last(last: str) -> timedelta:
+    unit = last[-1]
+    value = int(last[:-1])
+    if unit == "h":
+        return timedelta(hours=value)
+    if unit == "m":
+        return timedelta(minutes=value)
+    return timedelta(seconds=value)
+
+
+@router.get("/metrics/{device_id}")
+async def get_metrics(
+    device_id: str,
+    type: str,
+    last: str = Query("1h"),
+    session=Depends(get_session),
+) -> list[dict[str, float | str]]:
+    start = datetime.utcnow() - _parse_last(last)
+    stmt = (
+        select(
+            func.date_trunc("minute", DeviceMetric.ts).label("bucket"),
+            func.avg(DeviceMetric.value).label("value"),
+            DeviceMetric.unit,
+        )
+        .where(
+            DeviceMetric.device_id == device_id,
+            DeviceMetric.type == type,
+            DeviceMetric.ts >= start,
+        )
+        .group_by("bucket", DeviceMetric.unit)
+        .order_by("bucket")
+    )
+    res = await session.execute(stmt)
+    rows = res.all()
+    return [
+        {"ts": row.bucket.isoformat(), "value": row.value, "unit": row.unit}
+        for row in rows
+    ]
+

--- a/services/metrics-api/pyproject.toml
+++ b/services/metrics-api/pyproject.toml
@@ -12,6 +12,7 @@ sqlmodel = "^0.0.8"
 sqlalchemy = ">=1.4.17,<1.5.0"
 asyncpg = "^0.28.0"
 httpx = "^0.25.0"
+redis = "^5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## Summary
- publish device telemetry to Redis with `/v1/stream/<device_id>`
- fan out telemetry over websockets from gateway
- aggregate device metrics in metrics-api
- expose metrics query endpoint
- document streaming quick start
- add redis URL configuration and redis deps
- expose gateway port 8080 in compose

## Testing
- `ruff check .`
- `PYTHONPATH=.\:services/device-api pytest services/device-api/tests/test_stream.py::test_model_validation -q`
- `docker compose up --build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cdba98d88325b803a337c25d8a61