### PR TITLE
Initial infrastructure with Traefik and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# Cloud
+# SmartSecurity Cloud Backend
+
+This repository contains the containerised IoT backend for **SmartSecurity.Solutions**. The stack is composed of several FastAPI micro-services behind a Traefik reverse proxy with HTTPS, backed by PostgreSQL, Redis and MinIO.
+
+## Quick start
+
+1. Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) on your host.
+2. Clone this repository and change into the project directory.
+3. Launch the complete stack:
+
+```bash
+docker compose up -d
+```
+
+Traefik will obtain certificates from Let's Encrypt automatically. The API gateway will be available at `https://api.smartsecurity.solutions` once DNS points to your host.
+
+### Services
+
+- **gateway** – API gateway / BFF exposed through Traefik
+- **auth-api** – authentication and tenant/user management
+- **device-api** – CRUD operations for registered devices
+- **metrics-api** – ingestion and querying of device metrics
+- **postgres** – PostgreSQL 15 database
+- **redis** – Redis 7 instance
+- **minio** – S3-compatible object storage
+
+Environment variables for each service can be configured via the `.env.example` files located under `services/<service>`. Copy them to `.env` and adjust as needed.
+
+## API documentation
+
+Each micro-service exposes interactive documentation via FastAPI. When the stack is running, open the following URLs:
+
+- Gateway: `https://api.smartsecurity.solutions/docs`
+- Auth API: `http://auth:8000/docs` (internal)
+- Device API: `http://device:8000/docs` (internal)
+- Metrics API: `http://metrics:8000/docs` (internal)
+
+Only the gateway is exposed publicly; the other URLs are reachable from inside the Docker network.
+
+## Development
+
+The recommended workflow is to use the provided `docker compose` stack for a production-like environment. Subsequent documentation will cover local development, CI and deployment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,121 @@
+version: "3.9"
+
+services:
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencrypt.acme.email=admin@smartsecurity.solutions"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--api.dashboard=true"
+      - "--log.level=INFO"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./traefik/traefik.yml:/etc/traefik/traefik.yml:ro"
+      - "letsencrypt:/letsencrypt"
+    networks:
+      - web
+
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=smart
+      - POSTGRES_PASSWORD=smart
+      - POSTGRES_DB=smartsecurity
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+
+  redis:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redisdata:/data
+    networks:
+      - internal
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    volumes:
+      - miniodata:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    networks:
+      - internal
+
+  gateway:
+    build: ./services/gateway
+    env_file:
+      - ./services/gateway/.env.example
+    networks:
+      - internal
+      - web
+    depends_on:
+      - auth
+      - device
+      - metrics
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.gateway.rule=Host(`api.smartsecurity.solutions`)"
+      - "traefik.http.routers.gateway.entrypoints=websecure"
+      - "traefik.http.routers.gateway.tls.certresolver=letsencrypt"
+
+  auth:
+    build: ./services/auth-api
+    env_file:
+      - ./services/auth-api/.env.example
+    networks:
+      - internal
+    depends_on:
+      - postgres
+      - redis
+
+  device:
+    build: ./services/device-api
+    env_file:
+      - ./services/device-api/.env.example
+    networks:
+      - internal
+    depends_on:
+      - postgres
+
+  metrics:
+    build: ./services/metrics-api
+    env_file:
+      - ./services/metrics-api/.env.example
+    networks:
+      - internal
+    depends_on:
+      - postgres
+      - redis
+
+networks:
+  web:
+    external: false
+  internal:
+    internal: true
+
+volumes:
+  pgdata:
+  redisdata:
+  miniodata:
+  letsencrypt:

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,20 @@
+api:
+  dashboard: true
+
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+
+providers:
+  docker:
+    exposedByDefault: false
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: admin@smartsecurity.solutions
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web


### PR DESCRIPTION
## Summary
- set up docker-compose stack with Traefik, Postgres, Redis and MinIO
- add Traefik configuration
- document quick start and API docs in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cbaf2d9e483259d4e26f8862f53d5