### PR TITLE
Initialize FastAPI battery logging service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: cloud
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres" --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-root
+      - name: Ruff
+        run: poetry run ruff .
+      - name: Pytest
+        env:
+          POSTGRES_URL: postgresql+asyncpg://postgres:postgres@localhost/cloud
+          REDIS_URL: redis://localhost:6379/0
+        run: poetry run pytest -q
+      - name: Docker Build
+        run: docker build -t cloud:ci .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+.env
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+__pycache__/
+*.egg-info/
+.eggs/
+.python-version
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /app
+ENV POETRY_VERSION=1.6.1
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir "poetry==$POETRY_VERSION"
+COPY pyproject.toml poetry.lock* ./
+RUN poetry install --no-root --only main
+COPY . .
+CMD ["poetry", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # cloud
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `POSTGRES_URL` | SQLAlchemy async connection string for Postgres |
+| `REDIS_URL` | Redis connection URL |

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = $POSTGRES_URL
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,44 @@
+from logging.config import fileConfig
+import os
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+DATABASE_URL = os.getenv("POSTGRES_URL")
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL or "")
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=SQLModel.metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=SQLModel.metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,12 @@
+<%text>#
+# Generating script
+#</%text>
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade() -> None:
+${upgrades if upgrades else "    pass"}
+
+def downgrade() -> None:
+${downgrades if downgrades else "    pass"}

--- a/app/api/battery.py
+++ b/app/api/battery.py
@@ -1,0 +1,26 @@
+import os
+import json
+from fastapi import APIRouter
+import redis.asyncio as aioredis
+
+from ..db import async_session
+from ..models import BatteryLog
+from ..schemas import BatteryLogCreate, BatteryLogRead
+
+router = APIRouter(prefix="/api/v1/battery")
+
+
+@router.post("", response_model=BatteryLogRead)
+async def create_battery_log(payload: BatteryLogCreate) -> BatteryLogRead:
+    async with async_session() as session:
+        log = BatteryLog(**payload.model_dump())
+        session.add(log)
+        await session.commit()
+        await session.refresh(log)
+
+    redis_url = aioredis.from_url(
+        os.getenv("REDIS_URL", "redis://localhost:6379/0"), decode_responses=True
+    )
+    await redis_url.publish(f"battery:{payload.device_id}", json.dumps(payload.model_dump(), default=str))
+    await redis_url.close()
+    return BatteryLogRead.from_orm(log)

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,15 @@
+import os
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel
+
+DATABASE_URL = os.getenv("POSTGRES_URL", "postgresql+asyncpg://postgres:postgres@localhost/cloud")
+
+engine: AsyncEngine = create_async_engine(DATABASE_URL, echo=False)
+
+async_session: async_sessionmaker[AsyncSession] = async_sessionmaker(
+    engine, expire_on_commit=False
+)
+
+async def init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,30 @@
+import os
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+import redis.asyncio as aioredis
+
+from .api.battery import router as battery_router
+from .websocket_manager import WebSocketManager
+
+app = FastAPI()
+app.include_router(battery_router)
+
+manager = WebSocketManager()
+
+
+@app.websocket("/ws/battery")
+async def websocket_endpoint(websocket: WebSocket, device_id: str) -> None:
+    await manager.connect(websocket)
+    redis_url = aioredis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"), decode_responses=True)
+    pubsub = redis_url.pubsub()
+    await pubsub.subscribe(f"battery:{device_id}")
+    try:
+        async for message in pubsub.listen():
+            if message["type"] == "message":
+                await websocket.send_text(message["data"])
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await pubsub.unsubscribe(f"battery:{device_id}")
+        await pubsub.close()
+        await redis_url.close()
+        manager.disconnect(websocket)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+
+class BatteryLog(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    device_id: str
+    temp_c: float
+    health: str
+    ts: datetime

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+
+class BatteryLogBase(BaseModel):
+    device_id: str
+    temp_c: float
+    health: str
+    ts: datetime
+
+
+class BatteryLogCreate(BatteryLogBase):
+    pass
+
+
+class BatteryLogRead(BatteryLogBase):
+    model_config = ConfigDict(from_attributes=True)
+    id: int

--- a/app/websocket_manager.py
+++ b/app/websocket_manager.py
@@ -1,0 +1,18 @@
+from typing import Set
+from fastapi import WebSocket
+
+
+class WebSocketManager:
+    def __init__(self) -> None:
+        self.active_connections: Set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.add(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self.active_connections.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        for connection in list(self.active_connections):
+            await connection.send_text(message)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: cloud
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    restart: always
+  web:
+    build: .
+    ports:
+      - "443:8000"
+    environment:
+      POSTGRES_URL: postgresql+asyncpg://postgres:postgres@postgres/cloud
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - postgres
+      - redis
+volumes:
+  pgdata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "cloud"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110.0"
+sqlmodel = "^0.0.14"
+psycopg = {extras = ["binary"], version = "^3.1.12"}
+uvicorn = {extras = ["standard"], version = "^0.27.1"}
+redis = "^5.0.0"
+python-json-logger = "^2.0.7"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+pytest-asyncio = "^0.23.2"
+httpx = "^0.25.0"
+fakeredis = "^2.23.2"
+ruff = "^0.3.0"
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 100

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,41 @@
+import os
+os.environ.setdefault("POSTGRES_URL", "sqlite+aiosqlite:///:memory:")
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+import redis.asyncio as aioredis
+import fakeredis.aioredis
+
+from app.main import app
+from app.db import init_db
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db() -> None:
+    await init_db()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fake_redis(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis()
+    def _from_url(*args, **kwargs):
+        return fake
+    monkeypatch.setattr(aioredis, "from_url", _from_url)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_create_battery_log() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {
+            "device_id": "m05",
+            "temp_c": 34.2,
+            "health": "GOOD",
+            "ts": "2025-07-03T10:15:30Z",
+        }
+        response = await ac.post("/api/v1/battery", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["device_id"] == "m05"

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,0 +1,25 @@
+import os
+from fastapi.testclient import TestClient
+import redis.asyncio as aioredis
+import fakeredis.aioredis
+
+os.environ.setdefault("POSTGRES_URL", "sqlite+aiosqlite:///:memory:")
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def setup_module(module):
+    fake = fakeredis.aioredis.FakeRedis()
+
+    def _from_url(*args, **kwargs):
+        return fake
+
+    aioredis.from_url = _from_url
+
+
+def test_websocket_connect() -> None:
+    with client.websocket_connect("/ws/battery?device_id=test") as ws:
+        ws.send_text("ping")
+        assert ws


### PR DESCRIPTION
## Summary
- build `cloud` FastAPI project skeleton
- add async SQLModel database layer
- add battery log API and websocket
- setup Alembic and Docker compose
- configure GitHub Actions CI, Ruff, and tests

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866335723048325954222274fbcfe05